### PR TITLE
fix: Update instructions to deploy canister

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ npm run deploy:dev
 ## Deploying on mainnet
 
 ```
-npm run deploy:dev
+npm run deploy
 ```

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "preview": "vite preview",
     "lint": "eslint --max-warnings 0 \"src/**/*\"",
     "check": "svelte-check --tsconfig ./tsconfig.json && tsc -p tsconfig.node.json",
-    "deploy:dev": "vite build && cd canister && rm -r src/frontend && mkdir -p src/frontend && cp -r ../dist/* src/frontend/ && dfx deploy",
-    "deploy": "vite build && cd canister && rm -r src/frontend && mkdir -p src/frontend && cp -r ../dist/* src/frontend/ && dfx deploy --ic"
+    "deploy:dev": "vite build && cd canister && rm -rf src/frontend && mkdir -p src/frontend && cp -r ../dist/* src/frontend/ && dfx deploy",
+    "deploy": "vite build && cd canister && rm -rf src/frontend && mkdir -p src/frontend && cp -r ../dist/* src/frontend/ && dfx deploy --ic"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.1.1",


### PR DESCRIPTION
Update the README with the correct command to deploy to prod and also update the deploy script to force remove the `src/frontend` tmp directory as it gives an error the first time someone attempts to deploy the canister.