### PR TITLE
chore: Bump version of icp-calculator lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "icp-calculator-ui",
       "version": "0.0.0",
       "dependencies": {
-        "@dfinity/icp-calculator": "^0.0.5",
+        "@dfinity/icp-calculator": "^0.1.0",
         "@typescript-eslint/typescript-estree": "^8.7.0"
       },
       "devDependencies": {
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@dfinity/icp-calculator": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@dfinity/icp-calculator/-/icp-calculator-0.0.5.tgz",
-      "integrity": "sha512-TbfYqiCUs6DM4ves/LsiZOcAXVf7FBgto3c6iHDv86caSzZXxYwClo3Ou3tbQOjyTIPIjGMqzqf4NVzIpMeLrQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/icp-calculator/-/icp-calculator-0.1.0.tgz",
+      "integrity": "sha512-hbmFeEPyeJmVOdnNLztjSJFOIk06Dxc9oLMefkBLHn8bZzmT00nuRSuc7l5V4ry9tofHtZlQkbTMN0zkikD/4Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "vite": "^5.4.6"
   },
   "dependencies": {
-    "@dfinity/icp-calculator": "^0.0.5",
+    "@dfinity/icp-calculator": "^0.1.0",
     "@typescript-eslint/typescript-estree": "^8.7.0"
   }
 }


### PR DESCRIPTION
This PR updates the version of the icp-calculator library to pick up the recent changes to cycles costs.