### PR TITLE
chore: Force remove vite cache when deploying the canister

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "preview": "vite preview",
     "lint": "eslint --max-warnings 0 \"src/**/*\"",
     "check": "svelte-check --tsconfig ./tsconfig.json && tsc -p tsconfig.node.json",
-    "deploy:dev": "vite build && cd canister && rm -rf src/frontend && mkdir -p src/frontend && cp -r ../dist/* src/frontend/ && dfx deploy",
-    "deploy": "vite build && cd canister && rm -rf src/frontend && mkdir -p src/frontend && cp -r ../dist/* src/frontend/ && dfx deploy --ic"
+    "deploy:dev": "rm -rf node_modules/.vite && vite build && cd canister && rm -rf src/frontend && mkdir -p src/frontend && cp -r ../dist/* src/frontend/ && dfx deploy",
+    "deploy": "rm -rf node_modules/.vite && vite build && cd canister && rm -rf src/frontend && mkdir -p src/frontend && cp -r ../dist/* src/frontend/ && dfx deploy --ic"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.1.1",


### PR DESCRIPTION
Force removing the cache helps go around build issues where if only dependency updates happen (e.g. in package.json) and no source code changes, vite wouldn't pick up the changes. By removing the cache we force it to always use the latest of both source code and dependencies.